### PR TITLE
Added: fix for pass 'name' parameter via query map to prevent double URL-encoding and HTTP 404 errors.

### DIFF
--- a/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/AviVroClient.java
+++ b/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/AviVroClient.java
@@ -805,7 +805,8 @@ public class AviVroClient {
 		HashMap<String, String> map = new HashMap<String, String>();
 		map.put("include_name", "true");
 		if ((null != objectName) && (!objectName.isEmpty())) {
-			path = objectType + "?name=" + objectName;
+			path = objectType;
+			map.put("name", objectName);
 			data = session.get(path, map, userHeader);
 		} else {
 			logger.debug("Incorrect " + objectType + " name ");

--- a/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/model/TechSupportMessage.java
+++ b/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/model/TechSupportMessage.java
@@ -41,7 +41,10 @@ public class TechSupportMessage extends AviRestResource {
     private String url = "url";
 
 
-
+    @JsonProperty("uuid")
+    @JsonInclude(Include.NON_NULL)
+    private String uuid;
+    
   /**
    * This is the getter method this will return the attribute value.
    * 'techsupport status for the current invocation.'.


### PR DESCRIPTION
**Changes done**

  - In `AviVroClient.java` updated `getObjectDataByName` to include the name filter parameter in the query parameters Map instead of manually appending ?name= to the endpoint path string.
  
**Testing**

  -  Executed `AviVroTest` and confirmed unit tests pass.
  - Locally built and generated the plugin package (.dar file).
  - Verified end-to-end on a vcfa instance — confirmed objects are successfully created on the Avi Controller without errors.