### PR TITLE
Added: Fix version fallback logic for vRO plugin when outside supported range

### DIFF
--- a/o11nplugin-vro-core/pom.xml
+++ b/o11nplugin-vro-core/pom.xml
@@ -141,8 +141,12 @@
 			<artifactId>jaxb-runtime</artifactId>
 			<version>4.0.5</version>
 		</dependency>
-
-
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.11.0</version>
+			<scope>test</scope>
+		</dependency>
 		<!-- only for unit test cases -->
 		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime -->
 		<dependency>

--- a/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/VroPlugin.java
+++ b/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/VroPlugin.java
@@ -1,11 +1,13 @@
 package com.vmware.avi.vro;
 
 import java.io.IOException;
+import java.lang.Runtime.Version;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 
 import com.vmware.avi.sdk.AviApiException;
@@ -24,6 +26,13 @@ import ch.dunes.vso.sdk.api.IPluginFactory;
 @Scope(value = "prototype")
 public class VroPlugin {
 	public static final String TYPE = "Vro";
+	private final String minVersion;
+	private final String maxVersion;
+
+	public VroPlugin(@Value("${vRO.min_version}") String minVersion,@Value("${vRO.max_version}") String maxVersion){
+		this.minVersion = minVersion;
+		this.maxVersion = maxVersion;
+	}
 
 	private static final Logger log = LoggerFactory.getLogger(VroPlugin.class);
 
@@ -55,11 +64,13 @@ public class VroPlugin {
 		try {
 			log.debug("__INIT__:: Inside addVroClient ");
 			AviConnectionInfo aviConnectionInfo = new AviConnectionInfo();
+			String resolvedVersion = resolveVersion(version);
+			log.info("__INFO__:: Provided version {} and fallback version {}",version,resolvedVersion);
 			aviConnectionInfo.setController(controller);
 			aviConnectionInfo.setUsername(username);
 			aviConnectionInfo.setPassword(password);
 			aviConnectionInfo.setTenant(tenant);
-			aviConnectionInfo.setVersion(version);
+			aviConnectionInfo.setVersion(resolvedVersion);
 			aviConnectionInfo.setToken(token);
 			String addedController = controller + "-" + tenant;
 			aviConnectionInfo.setId(addedController);
@@ -73,6 +84,25 @@ public class VroPlugin {
 		return ctl;
 	}
 
+	private String resolveVersion(String version) {
+		if (compareVersions(version, this.minVersion) < 0) {
+			log.debug("__DEBUG__:: Provided version {} is below min version {}, falling back to min version", version,minVersion);
+			return minVersion;
+		}
+		if (compareVersions(version, this.maxVersion) > 0) {
+			log.debug("__DEBUG__:: Provided version {} is above max version {}, falling back to max version", version,maxVersion);
+			return maxVersion;
+		}
+		return version;
+	}
+
+	private int compareVersions(String v1, String v2) {
+		//it requires a numeric dot-separated sequence otherwise it will reject
+		if (v1 == null || v2 == null) {
+			throw new IllegalArgumentException("Version strings to compare cannot be null");
+		}
+		return Version.parse(v1).compareTo(Version.parse(v2));
+	}
 	/**
 	 * Method to store the all AVI endpoint
 	 *

--- a/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/configuration/ConfigurationServiceImpl.java
+++ b/o11nplugin-vro-core/src/main/java/com/vmware/avi/vro/configuration/ConfigurationServiceImpl.java
@@ -75,7 +75,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 			for (IEndpointConfiguration config : configs) {
 				AviConnectionInfo connectionInfo = getConnectionInfo(config);
 				if (connectionInfo != null) {
-					log.debug("Adding connection info to result map: " + connectionInfo);
+					log.debug("Adding connection info to result map: " + connectionInfo.getController());
 					result.add(connectionInfo);
 				}
 			}
@@ -130,7 +130,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 			log.debug("__DONE__:: Save Config method.");
 			return connectionInfo;
 		} catch (IOException e) {
-			log.error("Error saving connection " + connectionInfo, e);
+			log.error("Error saving connection for ip " + connectionInfo.getController(), e);
 			throw new RuntimeException(e);
 		}
 	}
@@ -145,7 +145,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 			endpointConfigurationService.deleteEndpointConfiguration(connectionInfo.getId().toString());
 			fireConnectionRemoved(connectionInfo);
 		} catch (IOException e) {
-			log.error("Error deleting endpoint configuration: " + connectionInfo, e);
+			log.error("Error deleting endpoint configuration for ip: " + connectionInfo.getController()	, e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/o11nplugin-vro-core/src/main/resources/application.properties
+++ b/o11nplugin-vro-core/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+vRO.min_version=20.1.7
+vRO.max_version=32.1.3

--- a/o11nplugin-vro-core/src/main/resources/com/vmware/avi/vro/pluginConfig.xml
+++ b/o11nplugin-vro-core/src/main/resources/com/vmware/avi/vro/pluginConfig.xml
@@ -10,7 +10,7 @@
             <context:include-filter type="annotation" expression="com.vmware.o11n.plugin.sdk.annotation.VsoFinder"/>
         <context:include-filter type="annotation" expression="com.vmware.o11n.plugin.sdk.annotation.VsoObject"/>
     </context:component-scan>
-
+    <context:property-placeholder location="classpath:application.properties" ignore-unresolvable="true"/>
     <import resource="classpath:com/vmware/o11n/plugin/sdk/spring/pluginEnv.xml"/>
     
     <bean class="com.vmware.avi.vro.VroPluginFactory" id="pluginFactory" autowire-candidate="false" scope="prototype">

--- a/o11nplugin-vro-core/src/test/java/com/vmware/avi/vro/AviVroPluginMockTest.java
+++ b/o11nplugin-vro-core/src/test/java/com/vmware/avi/vro/AviVroPluginMockTest.java
@@ -1,0 +1,99 @@
+package com.vmware.avi.vro;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import com.vmware.avi.vro.configuration.ConfigurationService;
+import com.vmware.avi.vro.model.AviConnectionInfo;
+import com.vmware.o11n.plugin.sdk.spring.platform.GlobalPluginNotificationHandler;
+
+public class AviVroPluginMockTest {
+
+    private static final String CONTROLLER = System.getenv("AVI_CONTROLLER");
+    private static final String USERNAME = System.getenv("AVI_USERNAME");
+    private static final String PASSWORD = System.getenv("AVI_PASSWORD");
+    private static final String VERSION = System.getenv("AVI_VERSION");
+    private static final String TENANT = System.getenv("AVI_TENANT");
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Mock
+    private GlobalPluginNotificationHandler notificationHandler;
+
+    private VroPlugin vroPlugin;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        Properties prop = new Properties();
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("application.properties")) {
+            prop.load(input);
+        }
+        String minVersion = prop.getProperty("vRO.min_version");
+        String maxVersion = prop.getProperty("vRO.max_version");
+        vroPlugin = new VroPlugin(minVersion, maxVersion);
+        Field configField = VroPlugin.class.getDeclaredField("configurationService");
+        configField.setAccessible(true);
+        configField.set(vroPlugin, configurationService);
+        Field notificationField = VroPlugin.class.getDeclaredField("notificationHandler");
+        notificationField.setAccessible(true);
+        notificationField.set(vroPlugin, notificationHandler);
+    }
+
+    @Test
+    public void testAddVroClient_Success() throws Exception {
+        String token = null;
+        String expectedId = CONTROLLER + "-" + TENANT;
+        when(configurationService.findById(expectedId)).thenReturn(null);
+        AviConnectionInfo savedInfo = new AviConnectionInfo();
+        savedInfo.setController(CONTROLLER);
+        when(configurationService.save(any(AviConnectionInfo.class))).thenReturn(savedInfo);
+
+        String result = vroPlugin.addVroClient(CONTROLLER, USERNAME, PASSWORD, TENANT, VERSION, token);
+
+        assertEquals(CONTROLLER, result);
+        verify(configurationService).findById(expectedId);
+        verify(configurationService).save(any(AviConnectionInfo.class));
+        verify(notificationHandler).notifyElementsInvalidate();
+    }
+
+    @Test(expected = Exception.class)
+    public void testAddVroClient_AlreadyExists() throws Exception {
+        String token = null;
+        String expectedId = CONTROLLER + "-" + TENANT;
+        AviConnectionInfo existingInfo = new AviConnectionInfo();
+        when(configurationService.findById(expectedId)).thenReturn(existingInfo);
+
+        vroPlugin.addVroClient(CONTROLLER, USERNAME, PASSWORD, TENANT, VERSION, token);
+    }
+
+    @Test
+    public void testRemoveVroClient_Success() throws Exception {
+        String controllerId = CONTROLLER + "-" + TENANT;
+        AviConnectionInfo existingInfo = new AviConnectionInfo();
+        existingInfo.setId(controllerId);
+        when(configurationService.findById(controllerId)).thenReturn(existingInfo);
+
+        vroPlugin.removeVroClient(controllerId);
+
+        verify(configurationService).findById(controllerId);
+        verify(configurationService).delete(existingInfo);
+    }
+
+    @Test(expected = Exception.class)
+    public void testRemoveVroClient_Exception() throws Exception {
+        String controllerId = CONTROLLER + "-" + TENANT;
+        when(configurationService.findById(controllerId)).thenThrow(new RuntimeException("Simulated error"));
+
+        vroPlugin.removeVroClient(controllerId);
+    }
+}

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,3 @@
-release_version=32.1.1
+min_version: 20.1.7
+release_version=32.1.3
 eng_version=32.2.1


### PR DESCRIPTION
**Changes done**

- Added logic for fallback version supported in `vRO plugin` for `32.1.3`.
- Accessing fallback version from `application.properties`.
-  Max Supported version = `32.1.3`.
- Min Supported version = `20.1.7`.
- Added `AviVroPluginMockTest.java` for mock testing for fallback version

**Testing done**

- Successfully tested and pass all the UT cases after applying fix. 
- Locally built and generated the plugin package (.dar file).
- Verified end-to-end on a vcfa instance — confirmed objects are successfully created on the Avi Controller without errors.
- For version above supported version

<img width="1346" height="159" alt="Screenshot 2026-09-09 at 8 50 55 AM" src="https://github.com/user-attachments/assets/0df48fa4-16d3-4859-96af-8853c3ef6624" />

- For version below supported version

<img width="1317" height="157" alt="Screenshot 2026-09-09 at 11 08 31 AM" src="https://github.com/user-attachments/assets/42caeb1d-f60e-4dbb-b96f-20df87dc74b6" />

- For Supported version range

<img width="1265" height="150" alt="Screenshot 2026-09-09 at 9 03 23 AM" src="https://github.com/user-attachments/assets/7cef49e5-6bd6-4d64-b83e-8262b6d2be69" />
